### PR TITLE
Refactor Makefile to support PowerPC64 LE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -369,13 +369,17 @@ ifneq (,$(findstring "$(PLATFORM)", "linux" "gnu_kfreebsd" "kfreebsd-gnu" "gnu")
     OPTIMIZE = $(OPTIMIZEVM) -ffast-math
     HAVE_VM_COMPILED=true
   else
-  ifeq ($(ARCH),ppc)
-    ALTIVEC_CFLAGS = -maltivec
+  ifneq ($(findstring $(ARCH),ppc ppc64 ppc64le),)
     HAVE_VM_COMPILED=true
   endif
+  ifeq ($(ARCH),ppc)
+    OPTIMIZE += -mcpu=powerpc
+  endif
   ifeq ($(ARCH),ppc64)
-    ALTIVEC_CFLAGS = -maltivec
-    HAVE_VM_COMPILED=true
+    OPTIMIZE += -mcpu=power7
+  endif
+  ifeq ($(ARCH),ppc64le)
+    OPTIMIZE += -mcpu=power8
   endif
   ifeq ($(ARCH),sparc)
     OPTIMIZE += -mtune=ultrasparc3 -mv8plus
@@ -424,10 +428,6 @@ ifneq (,$(findstring "$(PLATFORM)", "linux" "gnu_kfreebsd" "kfreebsd-gnu" "gnu")
   ifeq ($(ARCH),x86)
     # linux32 make ...
     BASE_CFLAGS += -m32
-  else
-  ifeq ($(ARCH),ppc64)
-    BASE_CFLAGS += -m64
-  endif
   endif
 else # ifeq Linux
 
@@ -2257,7 +2257,7 @@ ifeq ($(HAVE_VM_COMPILED),true)
     Q3OBJ += \
       $(B)/client/vm_x86.o
   endif
-  ifneq ($(findstring $(ARCH),ppc ppc64),)
+  ifneq ($(findstring $(ARCH),ppc ppc64 ppc64le),)
     Q3OBJ += $(B)/client/vm_powerpc.o $(B)/client/vm_powerpc_asm.o
   endif
   ifeq ($(ARCH),sparc)
@@ -2433,7 +2433,7 @@ ifeq ($(HAVE_VM_COMPILED),true)
     Q3DOBJ += \
       $(B)/ded/vm_x86.o
   endif
-  ifneq ($(findstring $(ARCH),ppc ppc64),)
+  ifneq ($(findstring $(ARCH),ppc ppc64 ppc64le),)
     Q3DOBJ += $(B)/ded/vm_powerpc.o $(B)/ded/vm_powerpc_asm.o
   endif
   ifeq ($(ARCH),sparc)


### PR DESCRIPTION
## Changes

* Use `-mcpu=powerpc` for PowerPC 32bit
* Use `-mcpu=power7` for PowerPC64 Big Endian
* Use `-mcpu=power8` for PowerPC64 Little Endian
* Remove `ALTIVEC_CFLAGS = -maltivec` and `BASE_CFLAGS += -m64`. Why? The `-mcpu` would automatically enable `-m64` and `-maltivec`
* Build QVM for PPC64LE

## NOTE

It is _ready_ for review

FYI, the build log can be found at https://gist.github.com/runlevel5/9f8bd6cfdedb21a53a31df0a374adde4